### PR TITLE
Fix eval device mismatch and checkpoint loading failure

### DIFF
--- a/latent_diffusion/data.py
+++ b/latent_diffusion/data.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("train")
 
 def load_samples():
     """ load all samples """
-    local_dir = os.getcwd().split("scripts/")[0]
+    local_dir = os.getcwd().split("latent_diffusion/")[0]
     samples_path = sorted(glob.glob(os.path.join(local_dir, "sample_data/ava_samples/*.npy")))
     samples = [np.load(sample_path, allow_pickle=True).item() for sample_path in samples_path]
     return samples
@@ -33,7 +33,7 @@ def load_samples():
 
 def load_batches(batch_size=2, num_views=2, resolution=1024, num_samples=10):
     """ load sample batches for overfitting """
-    local_dir = os.getcwd().split("scripts/")[0]
+    local_dir = os.getcwd().split("latent_diffusion/")[0]
     samples_path = sorted(glob.glob(os.path.join(local_dir, "sample_data/ava_samples/*.npy")))
     samples = [np.load(sample_path, allow_pickle=True).item() for sample_path in samples_path]
     samples = samples[:num_samples]

--- a/latent_diffusion/utils.py
+++ b/latent_diffusion/utils.py
@@ -8,6 +8,7 @@
 import copy
 import importlib
 import inspect
+import glob
 import logging
 import os
 from dataclasses import dataclass, field

--- a/scripts/pippo/generate_ref.py
+++ b/scripts/pippo/generate_ref.py
@@ -254,7 +254,10 @@ def generate_and_save(
         # keep only first sample
         for k,v in batch.items():
             if isinstance(v, (th.Tensor, np.ndarray, list)):
-                batch[k] = v[:1]
+                if isinstance(v, th.Tensor):
+                    batch[k] = v.to(device)[:1]
+                else:
+                    batch[k] = v[:1]
 
         gen_samples = []
         for i in range(n_views_per_sample):

--- a/train.py
+++ b/train.py
@@ -76,7 +76,7 @@ def train(config):
     train_loader = val_loader = cycle(train_data)
 
     # summary function
-    summary_fn = load_from_config(config.summary, map_location=device)
+    summary_fn = load_from_config(config.summary)
 
     # count parameters
     logger.info(

--- a/train.py
+++ b/train.py
@@ -56,7 +56,7 @@ def train(config):
     iteration, epoch = 0, 0
 
     # resume from checkpoint
-    ckpt_path = config.train.get("ckpt_path", None)
+    ckpt_path = config.train.get("ckpt_dir", None)
     if ckpt_path is not None:
         if os.path.exists(ckpt_path):
             ckpt_dict = load_checkpoint(
@@ -76,7 +76,7 @@ def train(config):
     train_loader = val_loader = cycle(train_data)
 
     # summary function
-    summary_fn = load_from_config(config.summary)
+    summary_fn = load_from_config(config.summary, map_location=device)
 
     # count parameters
     logger.info(


### PR DESCRIPTION
This commit addresses two issues:
1. Resolved a device mismatch problem during evaluation where input and weight tensors were placed on different devices, leading to runtime errors.
2. Fixed a checkpoint loading failure that caused training to restart from scratch instead of correctly resuming from the saved state.